### PR TITLE
Remove Str.graphemes. Used conversion to UTF-8 codepoints instead.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,8 @@ jobs:
     runs-on: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v3
-    
+
+      # get roc cli 
       - name: get latest roc nightly
         run: |
           curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-linux_x86_64-latest.tar.gz
@@ -31,10 +32,9 @@ jobs:
 
       - run: ./roc_nightly/roc version
 
-      - run: sudo apt install -y expect
       # expect for testing
-
+      - run: sudo apt install -y expect
       - run: expect -v
 
-      # Run all tests 
-      - run: ./ci/all_tests.sh
+      # run all tests 
+      - run: ROC=./roc_nightly/roc ./ci/all_tests.sh

--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -3,26 +3,35 @@
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
 set -euxo pipefail
 
-roc='./roc_nightly/roc'
+if [ -z "${ROC}" ]; then
+  echo "ERROR: The ROC environment variable is not set.
+    Set it to something like:
+        /home/username/Downloads/roc_nightly-linux_x86_64-2023-10-30-cb00cfb/roc
+        or
+        /home/username/gitrepos/roc/target/build/release/roc" >&2
 
-examples_dir='./examples/'
+  exit 1
+fi
+
+EXAMPLES_DIR='./examples'
+PACKAGE_DIR='./package'
 
 # roc check
-for roc_file in $examples_dir*.roc; do
-    $roc check $roc_file
+for ROC_FILE in $EXAMPLES_DIR/*.roc; do
+    $ROC check $ROC_FILE
 done
 
 # roc build
-for roc_file in $examples_dir*.roc; do
-    $roc build $roc_file --linker=legacy
+for ROC_FILE in $EXAMPLES_DIR/*.roc; do
+    $ROC build $ROC_FILE --linker=legacy
 done
 
 # check output
-for roc_file in $examples_dir*.roc; do
-    roc_file_only="$(basename "$roc_file")"
-    no_ext_name=${roc_file_only%.*}
-    expect ci/expect_scripts/$no_ext_name.exp
+for ROC_FILE in $EXAMPLES_DIR/*.roc; do
+    ROC_FILE_ONLY="$(basename "$ROC_FILE")"
+    NO_EXT_NAME=${ROC_FILE_ONLY%.*}
+    expect ci/expect_scripts/$NO_EXT_NAME.exp
 done
 
 # test building docs website
-$roc docs package/main.roc
+$ROC docs $PACKAGE_DIR/main.roc

--- a/package/Core.roc
+++ b/package/Core.roc
@@ -1848,9 +1848,8 @@ camelToKebabHelp = \{ taken, rest } ->
     when rest is
         [] -> { taken, rest }
         [a, ..] if isUpperCase a ->
-            # The codepoint for kebab - is 45.
             camelToKebabHelp {
-                taken: List.concat taken [45, toLowercase a],
+                taken: List.concat taken ['-', toLowercase a],
                 rest: List.dropFirst rest 1,
             }
 
@@ -1877,9 +1876,8 @@ camelToSnakeHelp = \{ taken, rest } ->
     when rest is
         [] -> { taken, rest }
         [a, ..] if isUpperCase a ->
-            # The codepoint for snake _ is 95.
             camelToSnakeHelp {
-                taken: List.concat taken [95, toLowercase a],
+                taken: List.concat taken ['_', toLowercase a],
                 rest: List.dropFirst rest 1,
             }
 
@@ -1903,25 +1901,21 @@ uppercaseFirst = \str ->
 
 toUppercase : U8 -> U8
 toUppercase = \codeunit ->
-    if 97 <= codeunit && codeunit <= 122 then
-        # Range of lowercase latin alphabet
-        # 32 is the difference to the respecive uppercase letters
-        codeunit - 32
+    if 'a' <= codeunit && codeunit <= 'z' then
+        codeunit - (32) # 32 is the difference to the respecive uppercase letters
     else
         codeunit
 
 toLowercase : U8 -> U8
 toLowercase = \codeunit ->
-    if 65 <= codeunit && codeunit <= 90 then
-        # Range of uppercase latin alphabet
-        # 32 is the difference to the respecive lowercase letters
-        codeunit + 32
+    if 'A' <= codeunit && codeunit <= 'Z' then
+        codeunit + 32 # 32 is the difference to the respecive lowercase letters
     else
         codeunit
 
 isUpperCase : U8 -> Bool
 isUpperCase = \codeunit ->
-    65 <= codeunit && codeunit <= 90
+    'A' <= codeunit && codeunit <= 'Z'
 
 eatWhitespace : List U8 -> List U8
 eatWhitespace = \bytes ->

--- a/package/main.roc
+++ b/package/main.roc
@@ -1,5 +1,5 @@
 package "json"
     exposes [
-        Core
+        Core,
     ]
     packages {}


### PR DESCRIPTION
Fixes #10.

Attention: This is only valid if we have object names using standard ASCII characters. I think JSON allows also any other character like non-latin letters, smilies and thelike ...

So maybe this PR provides only a intermediate result.