### PR TITLE
dont use specific basic-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can use the release URL package in your Roc app. In your `app.roc` file you 
 ```roc
 app "example"
     packages {
-        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.5.0/Cufzl36_SnJ4QbOoEmiJ5dIpUxBvdB3NEySvuH82Wio.tar.br",
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/[REPLACE WITH RELEASE URL].tar.br",
         json: "https://github.com/lukewilliamboswell/roc-json/releases/download/[REPLACE WITH RELEASE URL].tar.br",
     }
     ...


### PR DESCRIPTION
This prevents people from using old versions of basic-cli that may not even work with the latest roc nightly. It also prevents us from needing to update it every time :)