### PR TITLE
Add support for all things null and missing

### DIFF
--- a/package/Core.roc
+++ b/package/Core.roc
@@ -2058,7 +2058,8 @@ crashOnBadUtf8Error = \res ->
 
 nullChars = "null" |> Str.toUtf8
 
-## Returns Ok if the input is "null" or Err otherwise
+## Returns `Null` if the input starts with "null"
+## If makeNullEmpty is true Null{bytes} will be empty
 nullToEmpty : List U8, Bool -> [Null _, NotNull]
 nullToEmpty = \bytes, makeNullEmpty ->
     when bytes is

--- a/package/Core.roc
+++ b/package/Core.roc
@@ -93,19 +93,20 @@ Json := { fieldNameMapping : FieldNameMapping, skipMissingProperties : Bool, nul
     ]
 
 ## Returns a JSON `Encoder` and `Decoder`
-json = @Json { fieldNameMapping: Default, skipMissingProperties: Bool.true, nullAsUndefined: Bool.true, emptyEncodeAsNull: Bool.false }
+json = @Json { fieldNameMapping: Default, skipMissingProperties: Bool.true, nullAsUndefined: Bool.true, emptyEncodeAsNull: Bool.true }
 
 ## Returns a JSON `Encoder` and `Decoder` with configuration options
 ##
 ## **skipMissingProperties** - if `True` the decoder will skip additional properties
 ## in the json that are not present in the model. (Default: `True`)
+##
 ## **nullAsUndefined** - if `True` the decoder will convert `null` to an empty byte array.
-## This makes `{"email":null,`name`:"bob"}` decode the same as `{`name`:"bob"}`. (Default: `True`)
+## This makes `{"email":null,"name":"bob"}` decode the same as `{"name":"bob"}`. (Default: `True`)
+##
 ## **emptyEncodeAsNull** - if `True` encoders that return `[]` will result in a `null` in the
-## json when normally it would result in a record field, or list element, simply being ommitted.
-## eg:`{email:None, name:"bob"}` encodes to `{"email":null, "name":"bob"}`
-## instead of `{"name":"bob"}` (Default: `False`)
-jsonWithOptions = \{ fieldNameMapping ? Default, skipMissingProperties ? Bool.true, nullAsUndefined ? Bool.true, emptyEncodeAsNull ? Bool.false } ->
+## json. If `False` when an encoder returns `[]` the record field, or list/tuple element, will be ommitted.
+## eg: `{email:@Option None, name:"bob"}` encodes to `{"email":null, "name":"bob"}` instead of `{"name":"bob"}` (Default: `True`)
+jsonWithOptions = \{ fieldNameMapping ? Default, skipMissingProperties ? Bool.true, nullAsUndefined ? Bool.true, emptyEncodeAsNull ? Bool.true } ->
     @Json { fieldNameMapping, skipMissingProperties, nullAsUndefined, emptyEncodeAsNull }
 
 ## Mapping between Roc record fields and JSON object names

--- a/package/Option.roc
+++ b/package/Option.roc
@@ -1,0 +1,112 @@
+## Represents either a value, or nothing
+## If you need to distinguish between a missing field and a `null` field you should use `OptionOrNull`
+interface Option
+    exposes [none, some, get, getResult, from, fromResult]
+    imports [
+        Encode,
+        Core,
+    ]
+
+Option val := [Some val, None]
+    implements [
+        Eq,
+        Decoding {
+            decoder: decoderRes,
+        },
+        Encoding {
+            toEncoder: toEncoderRes,
+        },
+    ]
+## Missing or null
+none = \{} -> @Option (None)
+## A value
+some = \val -> @Option (Some val)
+get = \@Option val -> val
+getResult = \@Option val -> val
+## use like `Option.from Ok val`
+from = \val -> @Option val
+## Convert a result with any `Err` to an Option
+fromResult : Result a * -> _
+fromResult = \val ->
+    when val is
+        Ok a -> some a
+        Err _ -> none {}
+
+toEncoderRes = \@Option val ->
+    Encode.custom \bytes, fmt ->
+        when val is
+            Some contents -> bytes |> Encode.append contents fmt
+            None -> bytes
+
+decoderRes = Decode.custom \bytes, fmt ->
+    when bytes is
+        [] -> { result: Ok (none {}), rest: [] }
+        _ ->
+            when bytes |> Decode.decodeWith (Decode.decoder) fmt is
+                { result: Ok res, rest } -> { result: Ok (some res), rest }
+                { result: Err a, rest } -> { result: Err a, rest }
+
+## Used to indicate to roc highlighting that a string is json
+json = \a -> a
+
+OptionTest : { name : Str, lastName : Option Str, age : Option U8 }
+expect
+    decoded : Result OptionTest _
+    decoded =
+        """
+        { "age":1, "name":"hi" }
+        """
+        |> json
+        |> Str.toUtf8
+        |> Decode.fromBytes Core.json
+
+    expected = Ok ({ name: "hi", lastName: none {}, age: some 1u8 })
+    expected == decoded
+
+expect
+    decoded : Result OptionTest _
+    decoded =
+        """
+        { "age":1, "name":"hi", "lastName":null }
+        """
+        |> json
+        |> Str.toUtf8
+        |> Decode.fromBytes Core.json
+
+    expected = Ok ({ name: "hi", lastName: none {}, age: some 1u8 })
+    expected == decoded
+
+expect
+    toEncode : OptionTest
+    toEncode =
+        { name: "hi", lastName: none {}, age: some 1u8 }
+    encoded =
+        toEncode
+        |> Encode.toBytes Core.json
+        |> Str.fromUtf8
+
+    expected =
+        """
+        { "age":1, "name":"hi", "lastName":null }
+        """
+        |> json
+        |> Ok
+    expected == encoded
+
+expect
+    toEncode : OptionTest
+    toEncode =
+        { name: "hi", lastName: none {}, age: some 1u8 }
+    encoded =
+        toEncode
+        |> Encode.toBytes (Core.jsonWithOptions { emptyEncodeAsNull: Bool.false })
+        |> Str.fromUtf8
+
+    expected =
+        """
+        { "age":1, "name":"hi" }
+        """
+        |> json
+        |> Ok
+    expected == encoded
+

--- a/package/Option.roc
+++ b/package/Option.roc
@@ -99,7 +99,7 @@ expect
         { name: "hi", lastName: none {}, age: some 1u8 }
     encoded =
         toEncode
-        |> Encode.toBytes (Core.jsonWithOptions { emptyEncodeAsNull: Bool.false })
+        |> Encode.toBytes (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption {record:Bool.false} })
         |> Str.fromUtf8
 
     expected =

--- a/package/OptionOrNull.roc
+++ b/package/OptionOrNull.roc
@@ -1,0 +1,94 @@
+## Represents either a value, a missing field, or a null field
+## Normally you would only need `Option` but this type exists for use with APIs that
+## make a distinction between a json field being `null` and being missing altogether
+##
+## Ensure you set `nullAsUndefined` and `emptyEncodeAsNull` to false in your jsonOptions
+## eg: `core.jsonwithoptions { emptyencodeasnull: bool.false, nullasundefined: bool.false }`
+interface OptionOrNull
+    exposes [none, null, some, get, getResult, from]
+    imports [
+        Encode,
+        Core,
+    ]
+
+OptionOrNull val := [Some val, None, Null]
+    implements [
+        Eq,
+        Decoding {
+            decoder: decoderRes,
+        },
+        Encoding {
+            toEncoder: toEncoderRes,
+        },
+    ]
+
+## Missing field
+none = \{} -> @OptionOrNull (None)
+## Null
+null = \{} -> @OptionOrNull (Null)
+## Some value
+some = \val -> @OptionOrNull (Some val)
+
+## Get option internals.
+## For access to convinence methods and error accumulation you may want `Option.getResult`
+get = \@OptionOrNull val -> val
+
+## Option as a result
+getResult = \@OptionOrNull val ->
+    when val is
+        Some v -> Ok v
+        e -> Err e
+
+from = \val -> @OptionOrNull val
+
+nullChars = "null" |> Str.toUtf8
+
+toEncoderRes = \@OptionOrNull val ->
+    Encode.custom \bytes, fmt ->
+        when val is
+            Some contents -> bytes |> Encode.append contents fmt
+            None -> bytes
+            Null -> bytes |> List.concat (nullChars)
+
+decoderRes = Decode.custom \bytes, fmt ->
+    when bytes is
+        [] -> { result: Ok (none {}), rest: [] }
+        ['n', 'u', 'l', 'l', .. as rest] -> { result: Ok (null {}), rest: rest }
+        _ ->
+            when bytes |> Decode.decodeWith (Decode.decoder) fmt is
+                { result: Ok res, rest } -> { result: Ok (some res), rest }
+                { result: Err a, rest } -> { result: Err a, rest }
+
+## Used to indicate to roc highlighting that a string is json
+json = \a -> a
+
+OptionTest : { name : OptionOrNull Str, lastName : OptionOrNull Str, age : U8 }
+expect
+    decoded : Result OptionTest _
+    decoded =
+        """
+        {"name":null,"age":1}
+        """
+        |> json
+        |> Str.toUtf8
+        |> Decode.fromBytes (Core.jsonWithOptions { emptyEncodeAsNull: Bool.false, nullDecodeAsEmpty: Bool.false })
+
+    expected = Ok ({ age: 1u8, name: null {}, lastName: none {} })
+    expected == decoded
+
+# Encode Option None record with null
+expect
+    encoded =
+        dat : OptionTest
+        dat = { lastName: none {}, name: null {}, age: 1 }
+        Encode.toBytes dat (Core.jsonWithOptions { emptyEncodeAsNull: Bool.false })
+        |> Str.fromUtf8
+
+    expected =
+        """
+        {"age":1,"name":null}
+        """
+        |> json
+        |> Ok
+    expected == encoded
+

--- a/package/OptionOrNull.roc
+++ b/package/OptionOrNull.roc
@@ -71,7 +71,7 @@ expect
         """
         |> json
         |> Str.toUtf8
-        |> Decode.fromBytes (Core.jsonWithOptions { emptyEncodeAsNull: Bool.false, nullDecodeAsEmpty: Bool.false })
+        |> Decode.fromBytes (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption { record: Bool.false }, nullDecodeAsEmpty: Bool.false })
 
     expected = Ok ({ age: 1u8, name: null {}, lastName: none {} })
     expected == decoded
@@ -81,7 +81,8 @@ expect
     encoded =
         dat : OptionTest
         dat = { lastName: none {}, name: null {}, age: 1 }
-        Encode.toBytes dat (Core.jsonWithOptions { emptyEncodeAsNull: Bool.false })
+        dat
+        |> Encode.toBytes (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption { record: Bool.false } })
         |> Str.fromUtf8
 
     expected =

--- a/package/Testing.roc
+++ b/package/Testing.roc
@@ -1,0 +1,133 @@
+interface Testing
+    exposes []
+    imports [
+    Encode,Core
+    ]
+
+Option val := [None, Some val]
+    implements [
+        Eq,
+        Decoding {
+            decoder: optionDecode,
+        },
+        Encoding {
+            toEncoder: optionToEncode,
+        },
+    ]
+none = \{} -> @Option None
+some = \a -> @Option (Some a)
+
+optionToEncode = \@Option val ->
+    Encode.custom \bytes, fmt ->
+        when val is
+            Some contents -> bytes |> Encode.append contents fmt
+            None -> bytes
+
+#Encode Option none
+expect
+    encoded =
+        dat : Option U8
+        dat = @Option None
+        Encode.toBytes dat Core.json
+        |> Str.fromUtf8
+
+    expected = Ok ""
+    expected == encoded
+#Encode Option None record
+expect
+    encoded =
+        dat : { maybe : Option U8, other : Str }
+        dat = { maybe: none {}, other: "hi" }
+        Encode.toBytes dat Core.json
+        |> Str.fromUtf8
+
+    expected = Ok """{"other":"hi"}"""
+    expected == encoded
+# Encode Option Some record
+expect
+    encoded =
+        { maybe: some 10 }
+        |> Encode.toBytes Core.json
+        |> Str.fromUtf8
+
+    expected = Ok """{"maybe":10}"""
+    expected == encoded
+#Encode Option tuple
+expect
+    encoded =
+        dat:(U8,Option U8,Option Str,Str)
+        dat = (10,none{},some"opt","hi")
+        Encode.toBytes dat Core.json
+        |> Str.fromUtf8
+
+    expected = Ok """[10,"opt","hi"]"""
+    expected == encoded
+#Encode Option list
+expect
+    encoded =
+        dat = [some 1,none {},some 2,some 3]
+        Encode.toBytes dat Core.json
+        |> Str.fromUtf8
+
+    expected = Ok """[1,2,3]"""
+    expected == encoded
+
+optionDecode = Decode.custom \bytes, fmt ->
+    if bytes |> List.len == 0 then
+        { result: Ok (@Option (None)), rest: [] }
+    else
+        when bytes |> Decode.decodeWith (Decode.decoder) fmt is
+            { result: Ok res, rest } -> { result: Ok (@Option (Some res)), rest }
+            { result: Err a, rest } -> { result: Err a, rest }
+
+# Now I can try to modify the json decoding to try decoding every type with a zero byte buffer and see if that will decode my field
+OptionTest : { y : U8, maybe : Option U8 }
+expect
+    decoded : Result OptionTest _
+    decoded = """{"y":1}""" |> Str.toUtf8 |> Decode.fromBytes Core.json
+
+    expected = Ok ({ y: 1u8, maybe: none {} })
+    isGood =
+        when (decoded, expected) is
+            (Ok a, Ok b) ->
+                a == b
+
+            _ -> Bool.false
+    isGood == Bool.true
+
+OptionTest2 : { maybe : Option U8 }
+expect
+    decoded : Result OptionTest2 _
+    decoded =
+        """
+        {"maybe":1}
+        """
+        |> Str.toUtf8
+        |> Decode.fromBytes Core.json
+
+    expected = Ok ({ maybe: some 1u8 })
+    expected == decoded
+#Decode option list
+expect
+    decoded =
+        """
+        [1,2,3]
+        """
+        |> Str.toUtf8
+        |> Decode.fromBytes Core.json
+
+    expected = Ok [some 1,some 2, some 3]
+    expected == decoded
+#Decode Option Tuple
+#This doesn't really make sense unless none is encoded as "null"
+# expect
+#     decoded:Result(Option U8,Option U8 ,Option U8  ) _
+#     decoded =
+#         """
+#         [1,2]
+#         """
+#         |> Str.toUtf8
+#         |> Decode.fromBytes Core.json
+
+#     expected = Ok (some 1,none {}, some 2)
+#     expected == decoded

--- a/package/Testing.roc
+++ b/package/Testing.roc
@@ -82,6 +82,43 @@ expect
     expected = Ok "[1,2,3]"
     expected == encoded
 
+nullJson=Core.jsonWithOptions {emptyEncodeAsNull:Bool.true}
+# Encode Option None record with null
+expect
+    encoded =
+        dat : { maybe : Option U8, other : Str }
+        dat = { maybe: none {}, other: "hi" }
+        Encode.toBytes dat nullJson
+        |> Str.fromUtf8
+
+    expected = Ok
+        """
+        {"maybe":null,"other":"hi"}
+        """
+    expected == encoded
+# Encode Option tuple
+expect
+    encoded =
+        dat : (U8, Option U8, Option Str, Str)
+        dat = (10, none {}, some "opt", "hi")
+        Encode.toBytes dat nullJson
+        |> Str.fromUtf8
+
+    expected = Ok
+        """
+        [10,null,"opt","hi"]
+        """
+    expected == encoded
+# Encode Option list
+expect
+    encoded =
+        dat = [some 1, none {}, some 2, some 3]
+        Encode.toBytes dat nullJson
+        |> Str.fromUtf8
+
+    expected = Ok "[1,null,2,3]"
+    expected == encoded
+
 optionDecode = Decode.custom \bytes, fmt ->
     if bytes |> List.len == 0 then
         { result: Ok (@Option (None)), rest: [] }

--- a/package/Testing.roc
+++ b/package/Testing.roc
@@ -39,7 +39,7 @@ expect
     encoded =
         dat : { maybe : Option U8, other : Str }
         dat = { maybe: none {}, other: "hi" }
-        Encode.toBytes dat Core.json
+        Encode.toBytes dat (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption { record: Bool.false } })
         |> Str.fromUtf8
 
     expected = Ok
@@ -59,19 +59,6 @@ expect
         {"maybe":10}
         """
     expected == encoded
-# Encode Option tuple
-expect
-    encoded =
-        dat : (U8, Option U8, Option Str, Str)
-        dat = (10, none {}, some "opt", "hi")
-        Encode.toBytes dat Core.json
-        |> Str.fromUtf8
-
-    expected = Ok
-        """
-        [10,"opt","hi"]
-        """
-    expected == encoded
 # Encode Option list
 expect
     encoded =
@@ -82,13 +69,12 @@ expect
     expected = Ok "[1,2,3]"
     expected == encoded
 
-nullJson=Core.jsonWithOptions {emptyEncodeAsNull:Bool.true}
 # Encode Option None record with null
 expect
     encoded =
         dat : { maybe : Option U8, other : Str }
         dat = { maybe: none {}, other: "hi" }
-        Encode.toBytes dat nullJson
+        Encode.toBytes dat Core.json
         |> Str.fromUtf8
 
     expected = Ok
@@ -101,7 +87,7 @@ expect
     encoded =
         dat : (U8, Option U8, Option Str, Str)
         dat = (10, none {}, some "opt", "hi")
-        Encode.toBytes dat nullJson
+        Encode.toBytes dat Core.json
         |> Str.fromUtf8
 
     expected = Ok
@@ -113,7 +99,7 @@ expect
 expect
     encoded =
         dat = [some 1, none {}, some 2, some 3]
-        Encode.toBytes dat nullJson
+        Encode.toBytes dat (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption { list: Bool.true } })
         |> Str.fromUtf8
 
     expected = Ok "[1,null,2,3]"
@@ -170,18 +156,14 @@ expect
     expected == decoded
 
 # Decode Option Tuple
-# This doesn't really make sense unless none is encoded as "null", but that could be a worthwhile option
-
-# expect
-#     decoded:Result(Option U8,Option U8 ,Option U8  ) _
-#     decoded =
-#         """
-#         [1,2]
-#         """
-#         |> Str.toUtf8
-#         |> Decode.fromBytes Core.json
-#     expected = Ok (some 1,none {}, some 2)
-#     expected == decoded
+expect
+    decoded : Result (Option U8, Option U8, Option U8) _
+    decoded =
+        "[1,null,2]"
+        |> Str.toUtf8
+        |> Decode.fromBytes Core.json
+    expected = Ok (some 1, none {}, some 2)
+    expected == decoded
 
 # null decode
 expect

--- a/package/Testing.roc
+++ b/package/Testing.roc
@@ -1,7 +1,8 @@
 interface Testing
     exposes []
     imports [
-    Encode,Core
+        Encode,
+        Core,
     ]
 
 Option val := [None, Some val]
@@ -23,7 +24,7 @@ optionToEncode = \@Option val ->
             Some contents -> bytes |> Encode.append contents fmt
             None -> bytes
 
-#Encode Option none
+# Encode Option none
 expect
     encoded =
         dat : Option U8
@@ -33,7 +34,7 @@ expect
 
     expected = Ok ""
     expected == encoded
-#Encode Option None record
+# Encode Option None record
 expect
     encoded =
         dat : { maybe : Option U8, other : Str }
@@ -41,7 +42,10 @@ expect
         Encode.toBytes dat Core.json
         |> Str.fromUtf8
 
-    expected = Ok """{"other":"hi"}"""
+    expected = Ok
+        """
+        {"other":"hi"}
+        """
     expected == encoded
 # Encode Option Some record
 expect
@@ -50,26 +54,32 @@ expect
         |> Encode.toBytes Core.json
         |> Str.fromUtf8
 
-    expected = Ok """{"maybe":10}"""
+    expected = Ok
+        """
+        {"maybe":10}
+        """
     expected == encoded
-#Encode Option tuple
+# Encode Option tuple
 expect
     encoded =
-        dat:(U8,Option U8,Option Str,Str)
-        dat = (10,none{},some"opt","hi")
+        dat : (U8, Option U8, Option Str, Str)
+        dat = (10, none {}, some "opt", "hi")
         Encode.toBytes dat Core.json
         |> Str.fromUtf8
 
-    expected = Ok """[10,"opt","hi"]"""
+    expected = Ok
+        """
+        [10,"opt","hi"]
+        """
     expected == encoded
-#Encode Option list
+# Encode Option list
 expect
     encoded =
-        dat = [some 1,none {},some 2,some 3]
+        dat = [some 1, none {}, some 2, some 3]
         Encode.toBytes dat Core.json
         |> Str.fromUtf8
 
-    expected = Ok """[1,2,3]"""
+    expected = Ok "[1,2,3]"
     expected == encoded
 
 optionDecode = Decode.custom \bytes, fmt ->
@@ -84,7 +94,12 @@ optionDecode = Decode.custom \bytes, fmt ->
 OptionTest : { y : U8, maybe : Option U8 }
 expect
     decoded : Result OptionTest _
-    decoded = """{"y":1}""" |> Str.toUtf8 |> Decode.fromBytes Core.json
+    decoded =
+        """
+        {"y":1}
+        """
+        |> Str.toUtf8
+        |> Decode.fromBytes Core.json
 
     expected = Ok ({ y: 1u8, maybe: none {} })
     isGood =
@@ -107,19 +122,19 @@ expect
 
     expected = Ok ({ maybe: some 1u8 })
     expected == decoded
-#Decode option list
+# Decode option list
 expect
     decoded =
-        """
-        [1,2,3]
-        """
+        "[1,2,3]"
         |> Str.toUtf8
         |> Decode.fromBytes Core.json
 
-    expected = Ok [some 1,some 2, some 3]
+    expected = Ok [some 1, some 2, some 3]
     expected == decoded
-#Decode Option Tuple
-#This doesn't really make sense unless none is encoded as "null"
+
+# Decode Option Tuple
+# This doesn't really make sense unless none is encoded as "null", but that could be a worthwhile option
+
 # expect
 #     decoded:Result(Option U8,Option U8 ,Option U8  ) _
 #     decoded =
@@ -128,6 +143,24 @@ expect
 #         """
 #         |> Str.toUtf8
 #         |> Decode.fromBytes Core.json
-
 #     expected = Ok (some 1,none {}, some 2)
 #     expected == decoded
+
+# null decode
+expect
+    decoded : Result OptionTest _
+    decoded =
+        """
+        {"y":1,"maybe":null}
+        """
+        |> Str.toUtf8
+        |> Decode.fromBytes Core.json
+
+    expected = Ok ({ y: 1u8, maybe: none {} })
+    isGood =
+        when (decoded, expected) is
+            (Ok a, Ok b) ->
+                a == b
+
+            _ -> Bool.false
+    isGood == Bool.true

--- a/package/main.roc
+++ b/package/main.roc
@@ -1,5 +1,7 @@
 package "json"
     exposes [
         Core,
+        Option,
+        OptionOrNull
     ]
     packages {}


### PR DESCRIPTION
## Decoding:
Uses Changes made in roc compiler to support decoding records with missing fields
Option to treat null json values as missing fields

## Encoding:
Encode List with Encoders that return []
Encode tuple with encoders that return []
Encode record with encoders that return []
Option to insert null when encoders return [] instead of simply omitting the field/ element