### PR TITLE
WIP decoder updates, stuck on `lambda set region not resolved`

### DIFF
--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -33,5 +33,7 @@ for ROC_FILE in $EXAMPLES_DIR/*.roc; do
     expect ci/expect_scripts/$NO_EXT_NAME.exp
 done
 
+# TODO roc test everything
+
 # test building docs website
 $ROC docs $PACKAGE_DIR/main.roc

--- a/examples/simple1.roc
+++ b/examples/simple1.roc
@@ -1,38 +1,32 @@
 app "simple1"
     packages {
-        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.9.0/oKWkaruh2zXxin_xfsYsCJobH1tO8_JvNkFzDwwzNUQ.tar.br",
         json: "../package/main.roc", # use release URL (ends in tar.br) for local example, see github.com/lukewilliamboswell/roc-json/releases
     }
     imports [
         cli.Stdout,
         json.Core.{ jsonWithOptions },
-        Decode.{ DecodeResult, fromBytesPartial },
+        #Decode.{ DecodeResult, fromBytesPartial },
     ]
     provides [main] to cli
 
 main =
-    requestBody = Str.toUtf8 "{\"Image\":{\"Animated\":false,\"Height\":600,\"Ids\":[116,943,234,38793],\"Thumbnail\":{\"Height\":125,\"Url\":\"http:\\/\\/www.example.com\\/image\\/481989943\",\"Width\":100},\"Title\":\"View from 15th Floor\",\"Width\":800}}"
+    #requestBody = Str.toUtf8 "{\"Image\":{\"Animated\":false,\"Height\":600,\"Ids\":[116,943,234,38793],\"Thumbnail\":{\"Height\":125,\"Url\":\"http:\\/\\/www.example.com\\/image\\/481989943\",\"Width\":100},\"Title\":\"View from 15th Floor\",\"Width\":800}}"
+    requestBody = Str.toUtf8 "{\"Image\":{\"Height\":600}}"
 
-    decoder = jsonWithOptions { fieldNameMapping: PascalCase }
+    # decoder = jsonWithOptions { fieldNameMapping: PascalCase }
 
-    decoded : DecodeResult ImageRequest
-    decoded = fromBytesPartial requestBody decoder
+    Stdout.line "done"
 
-    when decoded.result is
-        Ok record -> Stdout.line "Successfully decoded image, title:\"\(record.image.title)\""
-        Err _ -> crash "Error, failed to decode image"
+    # decoded : DecodeResult ImageRequest
+    # decoded = fromBytesPartial requestBody decoder
+
+    # when decoded.result is
+    #     Ok record -> Stdout.line "Successfully decoded image, title:\"\(Num.toStr record.image.height)\""
+    #     Err _ -> crash "Error, failed to decode image"
 
 ImageRequest : {
     image : {
-        width : I64,
         height : I64,
-        title : Str,
-        thumbnail : {
-            url : Str,
-            height : F32,
-            width : F32,
-        },
-        animated : Bool,
-        ids : List U32,
     },
 }

--- a/examples/simple2.roc
+++ b/examples/simple2.roc
@@ -1,6 +1,6 @@
 app "simple2"
     packages {
-        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.9.0/oKWkaruh2zXxin_xfsYsCJobH1tO8_JvNkFzDwwzNUQ.tar.br",
         json: "../package/main.roc", # use release URL (ends in tar.br) for local example, see github.com/lukewilliamboswell/roc-json/releases
     }
     imports [

--- a/examples/tuple.roc
+++ b/examples/tuple.roc
@@ -1,6 +1,6 @@
 app "simple1"
     packages {
-        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.9.0/oKWkaruh2zXxin_xfsYsCJobH1tO8_JvNkFzDwwzNUQ.tar.br",
         json: "../package/main.roc", # use release URL (ends in tar.br) for local example, see github.com/lukewilliamboswell/roc-json/releases
     }
     imports [

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685908677,
-        "narHash": "sha256-E4zUPEUFyVWjVm45zICaHRpfGepfkE9Z2OECV9HXfA4=",
+        "lastModified": 1710868679,
+        "narHash": "sha256-V1o2bCZdeYKP/0zgVp4EN0KUjMItAMk6J7SvCXUI5IU=",
         "owner": "guibou",
         "repo": "nixGL",
-        "rev": "489d6b095ab9d289fe11af0219a9ff00fe87c7c5",
+        "rev": "d709a8abcde5b01db76ca794280745a43c8662be",
         "type": "github"
       },
       "original": {
@@ -102,16 +102,17 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1708440373,
-        "narHash": "sha256-TxSA0yWlpE58xrYI/sJR60Lj7dzUo39M58Umn2OY5xA=",
-        "owner": "roc-lang",
+        "lastModified": 1712598913,
+        "narHash": "sha256-COI1qtCi0OmZwpNFDOs+/A7LzyYoy19QOTlkQZUs9CM=",
+        "owner": "faldor20",
         "repo": "roc",
-        "rev": "b5f68bc02016e26b63fc833b6b1f5c9189a949f6",
+        "rev": "3fef8b9f82acb70c7fb8b142e886ac5dd4495fe6",
         "type": "github"
       },
       "original": {
-        "owner": "roc-lang",
+        "owner": "faldor20",
         "repo": "roc",
+        "rev": "3fef8b9f82acb70c7fb8b142e886ac5dd4495fe6",
         "type": "github"
       }
     },
@@ -137,11 +138,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695694299,
-        "narHash": "sha256-0CucEiOZzOVHwmGDJKNXLj7aDYOqbRtqChp9nbGrh18=",
+        "lastModified": 1712369449,
+        "narHash": "sha256-tbWug3uXPlSm1j0xD80Y3xbP+otT6gLnQo1e/vQat48=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c89a55d2d91cf55234466934b25deeffa365188a",
+        "rev": "41b3b080cc3e4b3a48e933b87fc15a05f1870779",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "json package devShell flake";
 
   inputs = {
-    roc.url = "github:roc-lang/roc";
+    roc.url = "github:faldor20/roc/3fef8b9f82acb70c7fb8b142e886ac5dd4495fe6";
     nixpkgs.follows = "roc/nixpkgs";
 
     # to easily make configs for multiple architectures


### PR DESCRIPTION
I'm using this Roc branch: https://github.com/faldor20/roc/tree/optional-decoding-works
```
❯ roc test ./package/Core.roc 
thread '<unnamed>' panicked at crates/compiler/solve/src/specialize.rs:866:25:
lambda set region not resolved: (`17.IdentId(76)`, MemberSpecializationInfo { _phase: PhantomData<roc_can::abilities::Resolved>, symbol: `17.IdentId(76)`, specialization_lambda_sets: VecMap { keys: [5, 1, 3, 2], values: [6909, 6917, 6405, 6408] } })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```