### PR TITLE
flake lock update, run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Json Package for Roc 🤘
 
-:warning: `--linker=legacy` is necessary for this package because of [this roc issue](https://github.com/roc-lang/roc/issues/3609) 
+:warning: On linux `--linker=legacy` is necessary for this package because of [this roc issue](https://github.com/roc-lang/roc/issues/3609) 
 
 ## Example 
 

--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -33,5 +33,22 @@ for ROC_FILE in $EXAMPLES_DIR/*.roc; do
     expect ci/expect_scripts/$NO_EXT_NAME.exp
 done
 
+# `roc test` every roc file if it contains a test, skip roc_nightly folder
+find . -type d -name "roc_nightly" -prune -o -type f -name "*.roc" -print | while read file; do
+    if grep -qE '^\s*expect(\s+|$)' "$file"; then
+
+        # don't exit script if test_command fails
+        set +e
+        test_command=$($ROC test "$file")
+        test_exit_code=$?
+        set -e
+
+        if [[ $test_exit_code -ne 0 && $test_exit_code -ne 2 ]]; then
+            exit $test_exit_code
+        fi
+    fi
+
+done
+
 # test building docs website
 $ROC docs $PACKAGE_DIR/main.roc

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685908677,
-        "narHash": "sha256-E4zUPEUFyVWjVm45zICaHRpfGepfkE9Z2OECV9HXfA4=",
+        "lastModified": 1710868679,
+        "narHash": "sha256-V1o2bCZdeYKP/0zgVp4EN0KUjMItAMk6J7SvCXUI5IU=",
         "owner": "guibou",
         "repo": "nixGL",
-        "rev": "489d6b095ab9d289fe11af0219a9ff00fe87c7c5",
+        "rev": "d709a8abcde5b01db76ca794280745a43c8662be",
         "type": "github"
       },
       "original": {
@@ -79,17 +79,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702900294,
-        "narHash": "sha256-pt7sSoJYNw3n8YtXw0Z/Nnr6/PfY2YrjDvqboErXnRM=",
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
         "type": "github"
       }
     },
@@ -102,11 +102,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1708440373,
-        "narHash": "sha256-TxSA0yWlpE58xrYI/sJR60Lj7dzUo39M58Umn2OY5xA=",
+        "lastModified": 1712930574,
+        "narHash": "sha256-9BIrDgumBUW3AHxoz3qTsPtBOGlVM+8uJOhL0MiGurE=",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "b5f68bc02016e26b63fc833b6b1f5c9189a949f6",
+        "rev": "237bd942ed1ed23b39f07ed1ee88dfe23c223fc5",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695694299,
-        "narHash": "sha256-0CucEiOZzOVHwmGDJKNXLj7aDYOqbRtqChp9nbGrh18=",
+        "lastModified": 1712369449,
+        "narHash": "sha256-tbWug3uXPlSm1j0xD80Y3xbP+otT6gLnQo1e/vQat48=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c89a55d2d91cf55234466934b25deeffa365188a",
+        "rev": "41b3b080cc3e4b3a48e933b87fc15a05f1870779",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The nix flake lock was updated to a more recent version of Roc. Other dependencies were updated as well.
`package/Core.roc` contained many tests, but they were not run in CI, I've added code that tests any Roc file containing expects.