### PR TITLE
Fix new import warnings

### DIFF
--- a/examples/simple1.roc
+++ b/examples/simple1.roc
@@ -6,7 +6,7 @@ app "simple1"
     imports [
         cli.Stdout,
         json.Core.{ jsonWithOptions },
-        Decode.{ DecodeResult, fromBytesPartial },
+        Decode.{ fromBytesPartial },
     ]
     provides [main] to cli
 

--- a/examples/simple2.roc
+++ b/examples/simple2.roc
@@ -7,7 +7,7 @@ app "simple2"
         cli.Stdout,
         cli.Task.{ await },
         json.Core.{ jsonWithOptions },
-        Decode.{ DecodeResult, fromBytesPartial },
+        Decode.{ fromBytesPartial },
         "data.json" as requestBody : List U8, 
     ]
     provides [main] to cli

--- a/examples/tuple.roc
+++ b/examples/tuple.roc
@@ -6,7 +6,7 @@ app "simple1"
     imports [
         cli.Stdout,
         json.Core.{ json },
-        Decode.{ DecodeResult, fromBytesPartial },
+        Decode.{ fromBytesPartial },
     ]
     provides [main] to cli
 

--- a/package/Core.roc
+++ b/package/Core.roc
@@ -40,8 +40,6 @@ interface Core
 
     imports [
         Encode.{
-            Encoder,
-            EncoderFormatting,
             appendWith,
         },
     ]
@@ -1488,7 +1486,7 @@ decodeRecord = \initialState, stepField, finalizer -> Decode.custom \bytes, @Jso
 
                             # Build final record from decoded fields and values
                             when finalizer updatedRecord json is
-                                ##This step is where i can implement my special decoding of options
+                                ## This step is where i can implement my special decoding of options
                                 Ok val -> { result: Ok val, rest }
                                 Err e ->
                                     { result: Err e, rest }


### PR DESCRIPTION
The next nightly will include the changes in roc-lang/roc#6658 which catches a few more cases of unused imports and will report warnings for unnecessary builtin imports.

This fixes all the warnings that will start to be reported for roc-json.