### PR TITLE
Rename Core.json to Json.utf8

### DIFF
--- a/examples/simple1.roc
+++ b/examples/simple1.roc
@@ -5,12 +5,12 @@ app [main] {
 
 import cli.Task
 import cli.Stdout
-import json.Core
+import json.Json
 
 main =
     requestBody = Str.toUtf8 "{\"Image\":{\"Animated\":false,\"Height\":600,\"Ids\":[116,943,234,38793],\"Thumbnail\":{\"Height\":125,\"Url\":\"http:\\/\\/www.example.com\\/image\\/481989943\",\"Width\":100},\"Title\":\"View from 15th Floor\",\"Width\":800}}"
 
-    decoder = Core.jsonWithOptions { fieldNameMapping: PascalCase }
+    decoder = Json.utf8With { fieldNameMapping: PascalCase }
 
     decoded : Decode.DecodeResult ImageRequest
     decoded = Decode.fromBytesPartial requestBody decoder

--- a/examples/simple2.roc
+++ b/examples/simple2.roc
@@ -5,11 +5,11 @@ app [main] {
 
 import cli.Stdout
 import cli.Task
-import json.Core
+import json.Json
 import "data.json" as requestBody : List U8
 
 main =
-    decoder = Core.jsonWithOptions {}
+    decoder = Json.utf8With {}
 
     decoded : Decode.DecodeResult (List DataRequest)
     decoded = Decode.fromBytesPartial requestBody decoder

--- a/examples/tuple.roc
+++ b/examples/tuple.roc
@@ -5,13 +5,13 @@ app [main] {
 
 import cli.Task
 import cli.Stdout
-import json.Core
+import json.Json
 
 main =
     bytes = Str.toUtf8 "[ [ 123,\n\"apples\" ], [  456,  \"oranges\" ]]"
 
     decoded : Decode.DecodeResult (List FruitCount)
-    decoded = Decode.fromBytesPartial bytes Core.json
+    decoded = Decode.fromBytesPartial bytes Json.utf8
 
     when decoded.result is
         Ok tuple -> Stdout.line! "Successfully decoded tuple, got $(toStr tuple)"

--- a/package/Json.roc
+++ b/package/Json.roc
@@ -32,7 +32,7 @@
 ## ```
 module [
     Json,
-    json,
+    utf8,
     jsonWithOptions,
     encodeAsNullOption,
 ]
@@ -85,7 +85,7 @@ Json := { fieldNameMapping : FieldNameMapping, skipMissingProperties : Bool, nul
     ]
 
 ## Returns a JSON `Encode.Encoder` and `Decoder`
-json = @Json { fieldNameMapping: Default, skipMissingProperties: Bool.true, nullDecodeAsEmpty: Bool.true, emptyEncodeAsNull: defaultEncodeAsNull }
+utf8 = @Json { fieldNameMapping: Default, skipMissingProperties: Bool.true, nullDecodeAsEmpty: Bool.true, emptyEncodeAsNull: defaultEncodeAsNull }
 
 ## Returns a JSON `Encode.Encoder` and `Decoder` with configuration options
 ##
@@ -199,7 +199,7 @@ encodeBool = \b ->
 # Test encode boolean
 expect
     input = [Bool.true, Bool.false]
-    actual = Encode.toBytes input json
+    actual = Encode.toBytes input utf8
     expected = Str.toUtf8 "[true,false]"
 
     actual == expected
@@ -280,7 +280,7 @@ expect escapedByteToJson '"' == ['\\', '"']
 # Test encode small string
 expect
     input = "G'day"
-    actual = Encode.toBytes input json
+    actual = Encode.toBytes input utf8
     expected = Str.toUtf8 "\"G'day\""
 
     actual == expected
@@ -288,7 +288,7 @@ expect
 # Test encode large string
 expect
     input = "the quick brown fox jumps over the lazy dog"
-    actual = Encode.toBytes input json
+    actual = Encode.toBytes input utf8
     expected = Str.toUtf8 "\"the quick brown fox jumps over the lazy dog\""
 
     actual == expected
@@ -296,7 +296,7 @@ expect
 # Test encode with escapes e.g. "\r" encodes to "\\r"
 expect
     input = "the quick brown fox jumps over the lazy doga\r\nbc\\\"xz"
-    actual = Encode.toBytes input json
+    actual = Encode.toBytes input utf8
     expected = Str.toUtf8 "\"the quick brown fox jumps over the lazy doga\\r\\nbc\\\\\\\"xz\""
 
     actual == expected
@@ -334,7 +334,7 @@ encodeList = \lst, encodeElem ->
 expect
     input : List F64
     input = [-1, 0.00001, 1e12, 2.0e-2, 0.0003, 43]
-    actual = Encode.toBytes input json
+    actual = Encode.toBytes input utf8
     expected = Str.toUtf8 "[-1,0.00001,1000000000000,0.02,0.0003,43]"
 
     actual == expected
@@ -448,7 +448,7 @@ encodeTuple = \elems ->
 # Test encode of tuple
 expect
     input = ("The Answer is", 42)
-    actual = Encode.toBytes input json
+    actual = Encode.toBytes input utf8
     expected = Str.toUtf8 "[\"The Answer is\",42]"
 
     actual == expected
@@ -501,7 +501,7 @@ decodeU8 = Decode.custom \bytes, @Json {} ->
 
 # Test decode of U8
 expect
-    actual = Str.toUtf8 "255" |> Decode.fromBytes json
+    actual = Str.toUtf8 "255" |> Decode.fromBytes utf8
     actual == Ok 255u8
 
 decodeU16 = Decode.custom \bytes, @Json {} ->
@@ -517,7 +517,7 @@ decodeU16 = Decode.custom \bytes, @Json {} ->
 
 # Test decode of U16
 expect
-    actual = Str.toUtf8 "65535" |> Decode.fromBytes json
+    actual = Str.toUtf8 "65535" |> Decode.fromBytes utf8
     actual == Ok 65_535u16
 
 decodeU32 = Decode.custom \bytes, @Json {} ->
@@ -533,7 +533,7 @@ decodeU32 = Decode.custom \bytes, @Json {} ->
 
 # Test decode of U32
 expect
-    actual = Str.toUtf8 "4000000000" |> Decode.fromBytes json
+    actual = Str.toUtf8 "4000000000" |> Decode.fromBytes utf8
     actual == Ok 4_000_000_000u32
 
 decodeU64 = Decode.custom \bytes, @Json {} ->
@@ -549,7 +549,7 @@ decodeU64 = Decode.custom \bytes, @Json {} ->
 
 # Test decode of U64
 expect
-    actual = Str.toUtf8 "18446744073709551614" |> Decode.fromBytes json
+    actual = Str.toUtf8 "18446744073709551614" |> Decode.fromBytes utf8
     actual == Ok 18_446_744_073_709_551_614u64
 
 decodeU128 = Decode.custom \bytes, @Json {} ->
@@ -565,7 +565,7 @@ decodeU128 = Decode.custom \bytes, @Json {} ->
 
 # Test decode of U128
 expect
-    actual = Str.toUtf8 "1234567" |> Decode.fromBytesPartial json
+    actual = Str.toUtf8 "1234567" |> Decode.fromBytesPartial utf8
     actual.result == Ok 1234567u128
 
 decodeI8 = Decode.custom \bytes, @Json {} ->
@@ -581,7 +581,7 @@ decodeI8 = Decode.custom \bytes, @Json {} ->
 
 # Test decode of I8
 expect
-    actual = Str.toUtf8 "-125" |> Decode.fromBytesPartial json
+    actual = Str.toUtf8 "-125" |> Decode.fromBytesPartial utf8
     actual.result == Ok -125i8
 
 decodeI16 = Decode.custom \bytes, @Json {} ->
@@ -597,7 +597,7 @@ decodeI16 = Decode.custom \bytes, @Json {} ->
 
 # Test decode of I16
 expect
-    actual = Str.toUtf8 "-32768" |> Decode.fromBytesPartial json
+    actual = Str.toUtf8 "-32768" |> Decode.fromBytesPartial utf8
     actual.result == Ok -32_768i16
 
 decodeI32 = Decode.custom \bytes, @Json {} ->
@@ -613,7 +613,7 @@ decodeI32 = Decode.custom \bytes, @Json {} ->
 
 # Test decode of I32
 expect
-    actual = Str.toUtf8 "-2147483648" |> Decode.fromBytesPartial json
+    actual = Str.toUtf8 "-2147483648" |> Decode.fromBytesPartial utf8
     actual.result == Ok -2_147_483_648i32
 
 decodeI64 = Decode.custom \bytes, @Json {} ->
@@ -629,7 +629,7 @@ decodeI64 = Decode.custom \bytes, @Json {} ->
 
 # Test decode of I64
 expect
-    actual = Str.toUtf8 "-9223372036854775808" |> Decode.fromBytesPartial json
+    actual = Str.toUtf8 "-9223372036854775808" |> Decode.fromBytesPartial utf8
     actual.result == Ok -9_223_372_036_854_775_808i64
 
 decodeI128 = Decode.custom \bytes, @Json {} ->
@@ -657,7 +657,7 @@ decodeF32 = Decode.custom \bytes, @Json {} ->
 # Test decode of F32
 expect
     actual : DecodeResult F32
-    actual = Str.toUtf8 "12.34e-5" |> Decode.fromBytesPartial json
+    actual = Str.toUtf8 "12.34e-5" |> Decode.fromBytesPartial utf8
     numStr = actual.result |> Result.map Num.toStr
 
     Result.withDefault numStr "" == "0.00012339999375399202"
@@ -676,7 +676,7 @@ decodeF64 = Decode.custom \bytes, @Json {} ->
 # Test decode of F64
 expect
     actual : DecodeResult F64
-    actual = Str.toUtf8 "12.34e-5" |> Decode.fromBytesPartial json
+    actual = Str.toUtf8 "12.34e-5" |> Decode.fromBytesPartial utf8
     numStr = actual.result |> Result.map Num.toStr
 
     Result.withDefault numStr "" == "0.0001234"
@@ -695,7 +695,7 @@ decodeDec = Decode.custom \bytes, @Json {} ->
 # Test decode of Dec
 expect
     actual : DecodeResult Dec
-    actual = Str.toUtf8 "12.0034" |> Decode.fromBytesPartial json
+    actual = Str.toUtf8 "12.0034" |> Decode.fromBytesPartial utf8
 
     actual.result == Ok 12.0034dec
 
@@ -707,13 +707,13 @@ decodeBool = Decode.custom \bytes, @Json {} ->
 
 # Test decode of Bool
 expect
-    actual = "true\n" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "true\n" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Ok Bool.true
     actual.result == expected
 
 # Test decode of Bool
 expect
-    actual = "false ]\n" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "false ]\n" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Ok Bool.false
     actual.result == expected
 
@@ -754,14 +754,14 @@ decodeTuple = \initialState, stepElem, finalizer -> Decode.custom \initialBytes,
 # Test decode of tuple
 expect
     input = Str.toUtf8 "[\"The Answer is\",42]"
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     actual.result == Ok ("The Answer is", 42)
 
 # Test decode with whitespace
 expect
     input = Str.toUtf8 "[ 123,\t456\n]"
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
     expected = Ok (123, 456)
 
     actual.result == expected
@@ -882,122 +882,122 @@ isValidEnd = \b ->
         _ -> Bool.false
 
 expect
-    actual = "0.0" |> Str.toUtf8 |> Decode.fromBytes json
+    actual = "0.0" |> Str.toUtf8 |> Decode.fromBytes utf8
     expected = Ok 0.0dec
     actual == expected
 
 expect
-    actual = "0" |> Str.toUtf8 |> Decode.fromBytes json
+    actual = "0" |> Str.toUtf8 |> Decode.fromBytes utf8
     expected = Ok 0u8
     actual == expected
 
 expect
-    actual = "1 " |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "1 " |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = { result: Ok 1dec, rest: [' '] }
     actual == expected
 
 expect
-    actual = "2]" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "2]" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = { result: Ok 2u64, rest: [']'] }
     actual == expected
 
 expect
-    actual = "30,\n" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "30,\n" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = { result: Ok 30i64, rest: [',', '\n'] }
     actual == expected
 
 expect
     actual : DecodeResult U16
-    actual = "+1" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "+1" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = { result: Err TooShort, rest: ['+', '1'] }
     actual == expected
 
 expect
     actual : DecodeResult U16
-    actual = ".0" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = ".0" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = { result: Err TooShort, rest: ['.', '0'] }
     actual == expected
 
 expect
     actual : DecodeResult U64
-    actual = "-.1" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "-.1" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     actual.result == Err TooShort
 
 expect
     actual : DecodeResult Dec
-    actual = "72" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "72" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Ok 72dec
     actual.result == expected
 
 expect
     actual : DecodeResult Dec
-    actual = "-0" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "-0" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Ok 0dec
     actual.result == expected
 
 expect
     actual : DecodeResult Dec
-    actual = "-7" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "-7" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Ok -7dec
     actual.result == expected
 
 expect
     actual : DecodeResult Dec
-    actual = "-0\n" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "-0\n" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = { result: Ok 0dec, rest: ['\n'] }
     actual == expected
 
 expect
     actual : DecodeResult Dec
-    actual = "123456789000 \n" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "123456789000 \n" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = { result: Ok 123456789000dec, rest: [' ', '\n'] }
     actual == expected
 
 expect
     actual : DecodeResult Dec
-    actual = "-12.03" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "-12.03" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Ok -12.03
     actual.result == expected
 
 expect
     actual : DecodeResult U64
-    actual = "-12." |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "-12." |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Err TooShort
     actual.result == expected
 
 expect
     actual : DecodeResult U64
-    actual = "01.1" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "01.1" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Err TooShort
     actual.result == expected
 
 expect
     actual : DecodeResult U64
-    actual = ".0" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = ".0" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Err TooShort
     actual.result == expected
 
 expect
     actual : DecodeResult U64
-    actual = "1.e1" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "1.e1" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Err TooShort
     actual.result == expected
 
 expect
     actual : DecodeResult U64
-    actual = "-1.2E" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "-1.2E" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Err TooShort
     actual.result == expected
 
 expect
     actual : DecodeResult U64
-    actual = "0.1e+" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "0.1e+" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Err TooShort
     actual.result == expected
 
 expect
     actual : DecodeResult U64
-    actual = "-03" |> Str.toUtf8 |> Decode.fromBytesPartial json
+    actual = "-03" |> Str.toUtf8 |> Decode.fromBytesPartial utf8
     expected = Err TooShort
     actual.result == expected
 
@@ -1223,7 +1223,7 @@ expect
 # Test decode simple string
 expect
     input = "\"hello\", " |> Str.toUtf8
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
     expected = Ok "hello"
 
     actual.result == expected
@@ -1231,7 +1231,7 @@ expect
 # Test decode string with extended and shorthand json escapes
 expect
     input = "\"h\\\"\\u0065llo\\n\"]\n" |> Str.toUtf8
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
     expected = Ok "h\"ello\n"
 
     actual.result == expected
@@ -1239,7 +1239,7 @@ expect
 # Test json string decoding with escapes
 expect
     input = Str.toUtf8 "\"a\r\nbc\\txz\"\t\n,  "
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
     expected = Ok "a\r\nbc\txz"
 
     actual.result == expected
@@ -1249,7 +1249,7 @@ expect
     input = Str.toUtf8 "null"
 
     actual : DecodeResult Str
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     Result.isErr actual.result
 
@@ -1361,7 +1361,7 @@ expect
     input = Str.toUtf8 "[ ]"
 
     actual : DecodeResult (List U8)
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     actual.result == Ok []
 
@@ -1370,7 +1370,7 @@ expect
     input = Str.toUtf8 "\n[\t 1 , 2  , 3]"
 
     actual : DecodeResult (List U64)
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok [1, 2, 3]
 
@@ -1381,7 +1381,7 @@ expect
     input = Str.toUtf8 "\n\t [\n \"one\"\r , \"two\" , \n\"3\"\t]"
 
     actual : DecodeResult (List Str)
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
     expected = Ok ["one", "two", "3"]
 
     actual.result == expected
@@ -1419,9 +1419,9 @@ decodeRecord = \initialState, stepField, finalizer -> Decode.custom \bytes, @Jso
         # Recursively build up record from object field:value pairs
         decodeFields = \recordState, bytesBeforeField ->
 
-            # Decode the json string field name
+            # Decode the JSON string field name
             { result: objectNameResult, rest: bytesAfterField } =
-                Decode.decodeWith bytesBeforeField decodeString json
+                Decode.decodeWith bytesBeforeField decodeString utf8
 
             # Count the bytes until the field value
             countBytesBeforeValue =
@@ -1478,7 +1478,7 @@ decodeRecord = \initialState, stepField, finalizer -> Decode.custom \bytes, @Jso
                             rest = List.dropFirst bytesAfterValue n
 
                             # Build final record from decoded fields and values
-                            when finalizer updatedRecord json is
+                            when finalizer updatedRecord utf8 is
                                 ## This step is where i can implement my special decoding of options
                                 Ok val -> { result: Ok val, rest }
                                 Err e ->
@@ -1558,7 +1558,7 @@ SkipValueState : [
 expect
     input = Str.toUtf8 "{\"extraField\":2, \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1569,7 +1569,7 @@ expect
 expect
     input = Str.toUtf8 "[{\"ownerName\": \"Farmer Joe\", \"extraField\":2}]"
     actual : DecodeResult (List { ownerName : Str })
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok [{ ownerName: "Farmer Joe" }]
 
@@ -1580,7 +1580,7 @@ expect
 expect
     input = Str.toUtf8 "{\"value\": {\"ownerName\": \"Farmer Joe\",\"extraField\":2}}"
     actual : DecodeResult { value : { ownerName : Str } }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { value: { ownerName: "Farmer Joe" } }
 
@@ -1591,7 +1591,7 @@ expect
 expect
     input = Str.toUtf8 "{\"value\": {\"ownerName\": \"Farmer Joe\", \"extraField\":2}, \"extraField\":2}"
     actual : DecodeResult { value : { ownerName : Str } }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { value: { ownerName: "Farmer Joe" } }
 
@@ -1602,7 +1602,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\":2, \"ownerName\": \"Farmer Joe\", \"extraField2\":2 }"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1613,7 +1613,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": \"abc\", \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1624,7 +1624,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": \"a,bc\", \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1635,7 +1635,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": \"a\\\"bc\", \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1646,7 +1646,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": [1,2,3], \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1657,7 +1657,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": [1,[4,5,[[9],6,7]],3], \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1668,7 +1668,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": [\"a\", [\"bc]]]def\"]], \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1679,7 +1679,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": [\"a\", [\"b\\cdef\"]], \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1690,7 +1690,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": { \"fieldA\": 6 }, \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1701,7 +1701,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": { \"fieldA\": 6, \"nested\": { \"nestField\": \"abcd\" } }, \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1712,7 +1712,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": { \"fieldA\": 6, \"nested\": { \"nestField\": \"ab}}}}}cd\" } }, \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 
@@ -1723,7 +1723,7 @@ expect
 expect
     input = Str.toUtf8 "{\"extraField\": { \"fieldA\": 6, \"nested\": { \"nestField\": \"ab\\cd\" } }, \"ownerName\": \"Farmer Joe\"}"
     actual : DecodeResult { ownerName : Str }
-    actual = Decode.fromBytesPartial input json
+    actual = Decode.fromBytesPartial input utf8
 
     expected = Ok { ownerName: "Farmer Joe" }
 

--- a/package/Json.roc
+++ b/package/Json.roc
@@ -33,7 +33,7 @@
 module [
     Json,
     utf8,
-    jsonWithOptions,
+    utf8With,
     encodeAsNullOption,
 ]
 
@@ -99,8 +99,8 @@ utf8 = @Json { fieldNameMapping: Default, skipMissingProperties: Bool.true, null
 ## json. If `False` when an encoder returns `[]` the record field, or list/tuple element, will be ommitted.
 ## eg: `{email:@Option None, name:"bob"}` encodes to `{"email":null, "name":"bob"}` instead of `{"name":"bob"}` (Default: `True`)
 
-jsonWithOptions : { fieldNameMapping ? FieldNameMapping, skipMissingProperties ? Bool, nullDecodeAsEmpty ? Bool, emptyEncodeAsNull ? EncodeAsNull } -> Json
-jsonWithOptions = \{ fieldNameMapping ? Default, skipMissingProperties ? Bool.true, nullDecodeAsEmpty ? Bool.true, emptyEncodeAsNull ? defaultEncodeAsNull } ->
+utf8With : { fieldNameMapping ? FieldNameMapping, skipMissingProperties ? Bool, nullDecodeAsEmpty ? Bool, emptyEncodeAsNull ? EncodeAsNull } -> Json
+utf8With = \{ fieldNameMapping ? Default, skipMissingProperties ? Bool.true, nullDecodeAsEmpty ? Bool.true, emptyEncodeAsNull ? defaultEncodeAsNull } ->
     @Json { fieldNameMapping, skipMissingProperties, nullDecodeAsEmpty, emptyEncodeAsNull }
 
 EncodeAsNull : {
@@ -378,7 +378,7 @@ encodeRecord = \fields ->
 # Test encode for a record with two strings ignoring whitespace
 expect
     input = { fruitCount: 2, ownerName: "Farmer Joe" }
-    encoder = jsonWithOptions { fieldNameMapping: PascalCase }
+    encoder = utf8With { fieldNameMapping: PascalCase }
     actual = Encode.toBytes input encoder
     expected = Str.toUtf8 "{\"FruitCount\":2,\"OwnerName\":\"Farmer Joe\"}"
 
@@ -387,7 +387,7 @@ expect
 # Test encode of record with an array of strings and a boolean field
 expect
     input = { fruitFlavours: ["Apples", "Bananas", "Pears"], isFresh: Bool.true }
-    encoder = jsonWithOptions { fieldNameMapping: KebabCase }
+    encoder = utf8With { fieldNameMapping: KebabCase }
     actual = Encode.toBytes input encoder
     expected = Str.toUtf8 "{\"fruit-flavours\":[\"Apples\",\"Bananas\",\"Pears\"],\"is-fresh\":true}"
 
@@ -396,7 +396,7 @@ expect
 # Test encode of record with a string and number field
 expect
     input = { firstSegment: "ab", secondSegment: 10u8 }
-    encoder = jsonWithOptions { fieldNameMapping: SnakeCase }
+    encoder = utf8With { fieldNameMapping: SnakeCase }
     actual = Encode.toBytes input encoder
     expected = Str.toUtf8 "{\"first_segment\":\"ab\",\"second_segment\":10}"
 
@@ -405,7 +405,7 @@ expect
 # Test encode of record of a record
 expect
     input = { outer: { inner: "a" }, other: { one: "b", two: 10u8 } }
-    encoder = jsonWithOptions { fieldNameMapping: Custom toYellingCase }
+    encoder = utf8With { fieldNameMapping: Custom toYellingCase }
     actual = Encode.toBytes input encoder
     expected = Str.toUtf8 "{\"OTHER\":{\"ONE\":\"b\",\"TWO\":10},\"OUTER\":{\"INNER\":\"a\"}}"
 
@@ -482,7 +482,7 @@ encodeTag = \name, payload ->
 # Test encode of tag
 expect
     input = TheAnswer "is" 42
-    encoder = jsonWithOptions { fieldNameMapping: KebabCase }
+    encoder = utf8With { fieldNameMapping: KebabCase }
     actual = Encode.toBytes input encoder
     expected = Str.toUtf8 "{\"TheAnswer\":[\"is\",42]}"
 
@@ -1390,7 +1390,7 @@ expect
 expect
     input = Str.toUtf8 "[{\"field_name\":1}]"
 
-    decoder = jsonWithOptions { fieldNameMapping: SnakeCase }
+    decoder = utf8With { fieldNameMapping: SnakeCase }
 
     actual : DecodeResult (List { fieldName : U64 })
     actual = Decode.fromBytesPartial input decoder
@@ -1403,7 +1403,7 @@ expect
 expect
     input = Str.toUtf8 "[{\"extraField\":2,\"fieldName\":1}]"
 
-    decoder = jsonWithOptions { skipMissingProperties: Bool.false }
+    decoder = utf8With { skipMissingProperties: Bool.false }
 
     actual : DecodeResult (List { fieldName : U64 })
     actual = Decode.fromBytesPartial input decoder
@@ -1765,7 +1765,7 @@ ObjectState : [
 # Test decode of record with two strings ignoring whitespace
 expect
     input = Str.toUtf8 " {\n\"FruitCount\"\t:2\n, \"OwnerName\": \"Farmer Joe\" } "
-    decoder = jsonWithOptions { fieldNameMapping: PascalCase }
+    decoder = utf8With { fieldNameMapping: PascalCase }
     actual = Decode.fromBytesPartial input decoder
     expected = Ok { fruitCount: 2, ownerName: "Farmer Joe" }
 
@@ -1774,7 +1774,7 @@ expect
 # Test decode of record with an array of strings and a boolean field
 expect
     input = Str.toUtf8 "{\"fruit-flavours\": [\"Apples\",\"Bananas\",\"Pears\"], \"is-fresh\": true }"
-    decoder = jsonWithOptions { fieldNameMapping: KebabCase }
+    decoder = utf8With { fieldNameMapping: KebabCase }
     actual = Decode.fromBytesPartial input decoder
     expected = Ok { fruitFlavours: ["Apples", "Bananas", "Pears"], isFresh: Bool.true }
 
@@ -1783,7 +1783,7 @@ expect
 # Test decode of record with a string and number field
 expect
     input = Str.toUtf8 "{\"first_segment\":\"ab\",\"second_segment\":10}"
-    decoder = jsonWithOptions { fieldNameMapping: SnakeCase }
+    decoder = utf8With { fieldNameMapping: SnakeCase }
     actual = Decode.fromBytesPartial input decoder
     expected = Ok { firstSegment: "ab", secondSegment: 10u8 }
 
@@ -1792,7 +1792,7 @@ expect
 # Test decode of record of a record
 expect
     input = Str.toUtf8 "{\"OUTER\":{\"INNER\":\"a\"},\"OTHER\":{\"ONE\":\"b\",\"TWO\":10}}"
-    decoder = jsonWithOptions { fieldNameMapping: Custom fromYellingCase }
+    decoder = utf8With { fieldNameMapping: Custom fromYellingCase }
     actual = Decode.fromBytesPartial input decoder
     expected = Ok { outer: { inner: "a" }, other: { one: "b", two: 10u8 } }
 
@@ -1826,7 +1826,7 @@ complexExampleRecord = {
 # Test decode of Complex Example
 expect
     input = complexExampleJson
-    decoder = jsonWithOptions { fieldNameMapping: PascalCase }
+    decoder = utf8With { fieldNameMapping: PascalCase }
     actual = Decode.fromBytes input decoder
     expected = Ok complexExampleRecord
 
@@ -1835,7 +1835,7 @@ expect
 # Test encode of Complex Example
 expect
     input = complexExampleRecord
-    encoder = jsonWithOptions { fieldNameMapping: PascalCase }
+    encoder = utf8With { fieldNameMapping: PascalCase }
     actual = Encode.toBytes input encoder
     expected = complexExampleJson
 

--- a/package/Option.roc
+++ b/package/Option.roc
@@ -2,7 +2,7 @@
 ## If you need to distinguish between a missing field and a `null` field you should use `OptionOrNull`
 module [none, some, get, getResult, from, fromResult]
 
-import Core
+import Json
 
 Option val := [Some val, None]
     implements [
@@ -55,7 +55,7 @@ expect
         """
         |> json
         |> Str.toUtf8
-        |> Decode.fromBytes Core.json
+        |> Decode.fromBytes Json.utf8
 
     expected = Ok ({ name: "hi", lastName: none {}, age: some 1u8 })
     expected == decoded
@@ -68,7 +68,7 @@ expect
         """
         |> json
         |> Str.toUtf8
-        |> Decode.fromBytes Core.json
+        |> Decode.fromBytes Json.utf8
 
     expected = Ok ({ name: "hi", lastName: none {}, age: some 1u8 })
     expected == decoded
@@ -80,7 +80,7 @@ expect
 #         { name: "hi", lastName: none {}, age: some 1u8 }
 #     encoded =
 #         toEncode
-#         |> Encode.toBytes Core.json
+#         |> Encode.toBytes Json.utf8
 #         |> Str.fromUtf8
 
 #     expected =
@@ -97,7 +97,7 @@ expect
 #         { name: "hi", lastName: none {}, age: some 1u8 }
 #     encoded =
 #         toEncode
-#         |> Encode.toBytes (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption { record: Bool.false } })
+#         |> Encode.toBytes (Json.utf8With { emptyEncodeAsNull: Json.encodeAsNullOption { record: Bool.false } })
 #         |> Str.fromUtf8
 
 #     expected =
@@ -107,4 +107,3 @@ expect
 #         |> json
 #         |> Ok
 #     expected == encoded
-

--- a/package/OptionOrNull.roc
+++ b/package/OptionOrNull.roc
@@ -6,7 +6,7 @@
 ## eg: `core.jsonwithoptions { emptyencodeasnull: bool.false, nullasundefined: bool.false }`
 module [none, null, some, get, getResult, from]
 
-import Core
+import Json
 
 OptionOrNull val := [Some val, None, Null]
     implements [
@@ -68,7 +68,7 @@ expect
         """
         |> json
         |> Str.toUtf8
-        |> Decode.fromBytes (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption { record: Bool.false }, nullDecodeAsEmpty: Bool.false })
+        |> Decode.fromBytes (Json.utf8With { emptyEncodeAsNull: Json.encodeAsNullOption { record: Bool.false }, nullDecodeAsEmpty: Bool.false })
 
     expected = Ok ({ age: 1u8, name: null {}, lastName: none {} })
     expected == decoded
@@ -79,7 +79,7 @@ expect
         dat : OptionTest
         dat = { lastName: none {}, name: null {}, age: 1 }
         dat
-        |> Encode.toBytes (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption { record: Bool.false } })
+        |> Encode.toBytes (Json.utf8With { emptyEncodeAsNull: Json.encodeAsNullOption { record: Bool.false } })
         |> Str.fromUtf8
 
     expected =
@@ -89,4 +89,3 @@ expect
         |> json
         |> Ok
     expected == encoded
-

--- a/package/Testing.roc
+++ b/package/Testing.roc
@@ -1,6 +1,6 @@
 module []
 
-import Core
+import Json
 
 Option val := [None, Some val]
     implements [
@@ -26,7 +26,7 @@ expect
     encoded =
         dat : Option U8
         dat = @Option None
-        Encode.toBytes dat Core.json
+        Encode.toBytes dat Json.utf8
         |> Str.fromUtf8
 
     expected = Ok ""
@@ -36,7 +36,7 @@ expect
     encoded =
         dat : { maybe : Option U8, other : Str }
         dat = { maybe: none {}, other: "hi" }
-        Encode.toBytes dat (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption { record: Bool.false } })
+        Encode.toBytes dat (Json.utf8With { emptyEncodeAsNull: Json.encodeAsNullOption { record: Bool.false } })
         |> Str.fromUtf8
 
     expected = Ok
@@ -48,7 +48,7 @@ expect
 expect
     encoded =
         { maybe: some 10 }
-        |> Encode.toBytes Core.json
+        |> Encode.toBytes Json.utf8
         |> Str.fromUtf8
 
     expected = Ok
@@ -60,7 +60,7 @@ expect
 expect
     encoded =
         dat = [some 1, none {}, some 2, some 3]
-        Encode.toBytes dat Core.json
+        Encode.toBytes dat Json.utf8
         |> Str.fromUtf8
 
     expected = Ok "[1,2,3]"
@@ -71,7 +71,7 @@ expect
     encoded =
         dat : { maybe : Option U8, other : Str }
         dat = { maybe: none {}, other: "hi" }
-        Encode.toBytes dat Core.json
+        Encode.toBytes dat Json.utf8
         |> Str.fromUtf8
 
     expected = Ok
@@ -84,7 +84,7 @@ expect
     encoded =
         dat : (U8, Option U8, Option Str, Str)
         dat = (10, none {}, some "opt", "hi")
-        Encode.toBytes dat Core.json
+        Encode.toBytes dat Json.utf8
         |> Str.fromUtf8
 
     expected = Ok
@@ -96,7 +96,7 @@ expect
 expect
     encoded =
         dat = [some 1, none {}, some 2, some 3]
-        Encode.toBytes dat (Core.jsonWithOptions { emptyEncodeAsNull: Core.encodeAsNullOption { list: Bool.true } })
+        Encode.toBytes dat (Json.utf8With { emptyEncodeAsNull: Json.encodeAsNullOption { list: Bool.true } })
         |> Str.fromUtf8
 
     expected = Ok "[1,null,2,3]"
@@ -119,7 +119,7 @@ expect
         {"y":1}
         """
         |> Str.toUtf8
-        |> Decode.fromBytes Core.json
+        |> Decode.fromBytes Json.utf8
 
     expected = Ok ({ y: 1u8, maybe: none {} })
     isGood =
@@ -138,7 +138,7 @@ expect
         {"maybe":1}
         """
         |> Str.toUtf8
-        |> Decode.fromBytes Core.json
+        |> Decode.fromBytes Json.utf8
 
     expected = Ok ({ maybe: some 1u8 })
     expected == decoded
@@ -147,7 +147,7 @@ expect
     decoded =
         "[1,2,3]"
         |> Str.toUtf8
-        |> Decode.fromBytes Core.json
+        |> Decode.fromBytes Json.utf8
 
     expected = Ok [some 1, some 2, some 3]
     expected == decoded
@@ -158,7 +158,7 @@ expect
     decoded =
         "[1,null,2]"
         |> Str.toUtf8
-        |> Decode.fromBytes Core.json
+        |> Decode.fromBytes Json.utf8
     expected = Ok (some 1, none {}, some 2)
     expected == decoded
 
@@ -170,7 +170,7 @@ expect
         {"y":1,"maybe":null}
         """
         |> Str.toUtf8
-        |> Decode.fromBytes Core.json
+        |> Decode.fromBytes Json.utf8
 
     expected = Ok ({ y: 1u8, maybe: none {} })
     isGood =

--- a/package/main.roc
+++ b/package/main.roc
@@ -1,5 +1,5 @@
 package [
-    Core,
+    Json,
     Option,
     OptionOrNull,
 ] {}


### PR DESCRIPTION
I think this reads a lot nicer when using it, e.g.

```roc
Http.get url Json.utf8
```

as opposed to today's

```roc
Http.get url Core.json
```

...or importing `json` unqualified, which isn't normally done outside of DSLs.

Also, this communicates that it expects the input bytes to be UTF-8, and in the future we could potentially add support for e.g. `Json.utf16` if there's interest in that.