### PR TITLE
Proposal: dynamic types and dicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ examples/simple1
 examples/simple2
 examples/tuple
 examples/http-get-json
+examples/dict
+examples/dynamic-types
 
 .DS_Store
 

--- a/ci/expect_scripts/dict.exp
+++ b/ci/expect_scripts/dict.exp
@@ -1,0 +1,17 @@
+#!/usr/bin/expect
+
+# uncomment line below for debugging
+# exp_internal 1
+
+set timeout 7
+
+spawn ./examples/dict
+
+
+expect "key_2: value_2" {
+    expect eof
+    exit 0
+}
+
+puts stderr "\nError: output was different from expected value."
+exit 1

--- a/ci/expect_scripts/dynamic-types.exp
+++ b/ci/expect_scripts/dynamic-types.exp
@@ -1,0 +1,17 @@
+#!/usr/bin/expect
+
+# uncomment line below for debugging
+# exp_internal 1
+
+set timeout 7
+
+spawn ./examples/dynamic-types
+
+
+expect "String: a text value\r\nNumber: 42" {
+    expect eof
+    exit 0
+}
+
+puts stderr "\nError: output was different from expected value."
+exit 1

--- a/examples/dict.roc
+++ b/examples/dict.roc
@@ -1,0 +1,25 @@
+app [main!] { 
+    cli: platform "https://github.com/roc-lang/basic-cli/releases/download/0.19.0/Hj-J_zxz7V9YurCSTFcFdu6cQJie4guzsPMUi5kBYUk.tar.br",
+    json: "../package/main.roc", # use release URL (ends in tar.br) for local example, see github.com/lukewilliamboswell/roc-json/releases
+}
+
+import cli.Stdout
+import json.Json
+
+main! = |_args|
+    dict = 
+        Decode.from_bytes(json_dict, Json.utf8)
+        |> Result.map_ok(Dict.from_list)
+        |> Result.with_default(Dict.empty({}))
+    when Dict.get(dict, "key_2") is
+        Ok(val) -> Stdout.line!("key_2: ${val}")
+        Err(_) -> Stdout.line!("key_2: not found")
+
+json_dict =
+    """
+    {
+        "key_1": "value_1",
+        "key_2": "value_2",
+    }
+    """
+    |> Str.to_utf8

--- a/examples/dict.roc
+++ b/examples/dict.roc
@@ -10,7 +10,7 @@ main! = |_args|
     dict = 
         Decode.from_bytes(json_dict, Json.utf8)
         |> Result.map_ok(Dict.from_list)
-        |> Result.with_default(Dict.empty({}))
+        |> Result.map_err(|e| Exit(1, "Error decoding JSON: ${Inspect.to_str(e)}"))?
     when Dict.get(dict, "key_2") is
         Ok(val) -> Stdout.line!("key_2: ${val}")
         Err(_) -> Stdout.line!("key_2: not found")

--- a/examples/dynamic-types.roc
+++ b/examples/dynamic-types.roc
@@ -6,7 +6,13 @@ app [main!] {
 import cli.Stdout
 import json.Json
 
+# Json objects may contain dynamically typed values. These may be decoded (if the stored in an object `{...}`)
+# by first decoding as a Str, then making a second decoding pass on the initial Str value.
+
+## The initially decoded object - value is a dynamically typed object, decoded as a Str
 DynamicJson : { type : Str, value : Str }
+
+# The final decoded object - dynamically typed value stored as a Tag union
 Dynamic : { value : [String(Str), Number(U64)] }
 
 dynamic_json =

--- a/examples/dynamic-types.roc
+++ b/examples/dynamic-types.roc
@@ -12,7 +12,7 @@ import json.Json
 ## The initially decoded object - value is a dynamically typed object, decoded as a Str
 DynamicJson : { type : Str, value : Str }
 
-# The final decoded object - dynamically typed value stored as a Tag union
+## The final decoded object - dynamically typed value stored as a Tag union
 Dynamic : { value : [String(Str), Number(U64)] }
 
 dynamic_json =
@@ -69,5 +69,5 @@ main! = |_args|
                     Number(val) ->
                         Stdout.line!("Number: ${Num.to_str(val)}")
             )
-        Err(_) ->
-            Stdout.line!("Error decoding JSON")
+        Err(e) ->
+            Stdout.line!("Error decoding JSON: ${Inspect.to_str(e)}")

--- a/examples/dynamic-types.roc
+++ b/examples/dynamic-types.roc
@@ -1,0 +1,67 @@
+app [main!] {
+    cli: platform "https://github.com/roc-lang/basic-cli/releases/download/0.19.0/Hj-J_zxz7V9YurCSTFcFdu6cQJie4guzsPMUi5kBYUk.tar.br",
+    json: "../package/main.roc", # use release URL (ends in tar.br) for local example, see github.com/lukewilliamboswell/roc-json/releases
+}
+
+import cli.Stdout
+import json.Json
+
+DynamicJson : { type : Str, value : Str }
+Dynamic : { value : [String(Str), Number(U64)] }
+
+dynamic_json =
+    """
+    [
+        {
+            "type": "String",
+            "value": { "s": "a text value" }
+        },
+        {
+            "type": "Number",
+            "value": { "n": 42 }
+        }
+    ]
+    """
+    |> Str.to_utf8
+
+decode_dynamic : List U8 -> Result (List Dynamic) DecodeError
+decode_dynamic = |bytes|
+    decoded : DecodeResult (List DynamicJson)
+    decoded = Decode.from_bytes_partial(bytes, Json.utf8)
+    decoded.result
+    |> Result.map_ok(
+        |dyn_list|
+            List.keep_oks(
+                dyn_list,
+                |dynamic|
+                    when dynamic.type is
+                        "String" ->
+                            dynamic.value
+                            |> Str.to_utf8
+                            |> Decode.from_bytes(Json.utf8)
+                            |> Result.map_ok(|val| { value: String(val.s) })
+
+                        "Number" ->
+                            dynamic.value
+                            |> Str.to_utf8
+                            |> Decode.from_bytes(Json.utf8)
+                            |> Result.map_ok(|val| { value: Number(val.n) })
+
+                        _ ->
+                            Err(UnknownType),
+            ),
+    )
+
+main! = |_args|
+    when decode_dynamic(dynamic_json) is
+        Ok(list) ->
+            List.for_each_try!(list, |item|
+                when item.value is
+                    String(val) ->
+                        Stdout.line!("String: ${val}")
+
+                    Number(val) ->
+                        Stdout.line!("Number: ${Num.to_str(val)}")
+            )
+        Err(_) ->
+            Stdout.line!("Error decoding JSON")

--- a/package/Json.roc
+++ b/package/Json.roc
@@ -959,19 +959,6 @@ parse_exact_char = |bytes, char|
 
         Err(_) -> { result: Err(TooShort), rest: bytes }
 
-# parse_char_choice : List U8, List U8 -> DecodeResult {}
-# parse_char_choice = |bytes, chars|
-#     when List.get(bytes, 0) is
-#         Ok(c) ->
-#             if
-#                 List.contains(chars, c)
-#             then
-#                 { result: Ok({}), rest: (List.split_at(bytes, 1)).others }
-#             else
-#                 { result: Err(TooShort), rest: bytes }
-
-#         Err(_) -> { result: Err(TooShort), rest: bytes }
-
 open_bracket : List U8 -> DecodeResult {}
 open_bracket = |bytes| parse_exact_char(bytes, '[')
 

--- a/package/Json.roc
+++ b/package/Json.roc
@@ -849,9 +849,9 @@ decode_tuple = |initial_state, step_elem, finalizer|
                 try_decode(
                     decode_attempt,
                     |{ val: new_state, rest: before_comma_or_break }|
-                        { result: delimiter_result, rest: next_bytes } = comma(before_comma_or_break)
+                        { result: comma_result, rest: next_bytes } = comma(before_comma_or_break)
 
-                        when delimiter_result is
+                        when comma_result is
                             Ok({}) -> decode_elems(step_elem, new_state, (index + 1), next_bytes)
                             Err(_) -> { result: Ok(new_state), rest: next_bytes },
                 )
@@ -873,11 +873,11 @@ decode_tuple = |initial_state, step_elem, finalizer|
                 try_decode(
                     decode_attempt,
                     |{ val: new_state, rest: before_colon_or_break }|
-                        { result: delimiter_result, rest: next_bytes } = 
+                        { result: colon_result, rest: next_bytes } = 
                             eat_whitespace(before_colon_or_break)
                             |> colon
 
-                        when delimiter_result is
+                        when colon_result is
                             Ok({}) -> decode_dict_elems(step_elem, new_state, (index + 1), next_bytes)
                             Err(_) -> { result: Ok(new_state), rest: next_bytes },
                 )

--- a/package/Json.roc
+++ b/package/Json.roc
@@ -849,13 +849,39 @@ decode_tuple = |initial_state, step_elem, finalizer|
                 try_decode(
                     decode_attempt,
                     |{ val: new_state, rest: before_comma_or_break }|
-                        { result: comma_result, rest: next_bytes } = comma(before_comma_or_break)
+                        { result: delimiter_result, rest: next_bytes } = comma(before_comma_or_break)
 
-                        when comma_result is
+                        when delimiter_result is
                             Ok({}) -> decode_elems(step_elem, new_state, (index + 1), next_bytes)
                             Err(_) -> { result: Ok(new_state), rest: next_bytes },
                 )
 
+            decode_dict_elems = |stepper, state, index, bytes|
+                decode_attempt =
+                    when stepper(state, index) is
+                        TooLong ->
+                            bytes
+                            |> anything
+                            |> try_decode(
+                                |{ rest: before_colon_or_break }|
+                                    { result: Ok(state), rest: before_colon_or_break },
+                            )
+
+                        Next(decoder) ->
+                            decode_potential_null(eat_whitespace(bytes), decoder, json_fmt)
+
+                try_decode(
+                    decode_attempt,
+                    |{ val: new_state, rest: before_colon_or_break }|
+                        { result: delimiter_result, rest: next_bytes } = 
+                            eat_whitespace(before_colon_or_break)
+                            |> colon
+
+                        when delimiter_result is
+                            Ok({}) -> decode_dict_elems(step_elem, new_state, (index + 1), next_bytes)
+                            Err(_) -> { result: Ok(new_state), rest: next_bytes },
+                )
+                
             initial_bytes
             |> open_bracket
             |> try_decode(
@@ -872,7 +898,23 @@ decode_tuple = |initial_state, step_elem, finalizer|
                                         Err(e) -> { result: Err(e), rest: after_tuple_bytes },
                             ),
                     ),
-            ),
+            )
+            |> |decode_result|
+                when decode_result.result is
+                    Ok(_) -> 
+                        decode_result
+
+                    Err(TooShort) ->
+                        # If decoding a normal tuple fails, try decoding as a k/v -> tuple
+                        decode_dict_elems(step_elem, initial_state, 0, eat_whitespace(initial_bytes))
+                        |> try_decode(
+                            |{ val: end_state_result, rest: after_last_elem_bytes }|
+                                after_tuple_bytes = eat_whitespace(after_last_elem_bytes)
+                                when finalizer(end_state_result) is
+                                    Ok(val) -> { result: Ok(val), rest: after_tuple_bytes }
+                                    Err(e) -> { result: Err(e), rest: after_tuple_bytes },
+                        ),
+
     )
 
 # Test decode of tuple
@@ -890,6 +932,20 @@ expect
 
     actual.result == expected
 
+# Test decode of key-val to tuple
+expect
+    input = Str.to_utf8("\"Key\" : \"Value\"")
+    actual = Decode.from_bytes_partial(input, utf8)
+
+    actual.result == Ok(("Key", "Value"))
+
+# Test decode json object to list of tuples
+expect
+    input = Str.to_utf8("{\"k\":1, \"k2\": 2}")
+    actual = Decode.from_bytes_partial(input, utf8)
+
+    actual.result == Ok([("k", 1), ("k2", 2)])
+
 parse_exact_char : List U8, U8 -> DecodeResult {}
 parse_exact_char = |bytes, char|
     when List.get(bytes, 0) is
@@ -903,6 +959,19 @@ parse_exact_char = |bytes, char|
 
         Err(_) -> { result: Err(TooShort), rest: bytes }
 
+# parse_char_choice : List U8, List U8 -> DecodeResult {}
+# parse_char_choice = |bytes, chars|
+#     when List.get(bytes, 0) is
+#         Ok(c) ->
+#             if
+#                 List.contains(chars, c)
+#             then
+#                 { result: Ok({}), rest: (List.split_at(bytes, 1)).others }
+#             else
+#                 { result: Err(TooShort), rest: bytes }
+
+#         Err(_) -> { result: Err(TooShort), rest: bytes }
+
 open_bracket : List U8 -> DecodeResult {}
 open_bracket = |bytes| parse_exact_char(bytes, '[')
 
@@ -914,6 +983,9 @@ anything = |bytes| { result: Err(TooShort), rest: bytes }
 
 comma : List U8 -> DecodeResult {}
 comma = |bytes| parse_exact_char(bytes, ',')
+
+colon : List U8 -> DecodeResult {}
+colon = |bytes| parse_exact_char(bytes, ':')
 
 try_decode : DecodeResult a, ({ val : a, rest : List U8 } -> DecodeResult b) -> DecodeResult b
 try_decode = |{ result, rest }, mapper|
@@ -1143,12 +1215,17 @@ decode_string = Decode.custom(
             # Remove starting and ending quotation marks, replace unicode
             # escpapes with Roc equivalent, and try to parse RocStr from
             # bytes
+            { start, from_end } = 
+                when List.get(str_bytes, 0) is 
+                    Ok('{') -> { start: 0, from_end: 0 } # decode object as str
+                    _ -> { start: 1, from_end: 2 }
+
             result =
                 str_bytes
                 |> List.sublist(
                     {
-                        start: 1,
-                        len: Num.sub_saturated(List.len(str_bytes), 2),
+                        start,
+                        len: Num.sub_saturated(List.len(str_bytes), from_end),
                     },
                 )
                 |> |bytes_without_quotation_marks|
@@ -1163,6 +1240,12 @@ decode_string = Decode.custom(
                 Err(_) ->
                     { result: Err(TooShort), rest: bytes },
 )
+
+expect
+    input = "{ \"object\": {\"k\": \"v\"} }" |> Str.to_utf8
+    actual = Decode.from_bytes_partial(input, utf8)
+
+    actual.result == Ok({ object: "{\"k\": \"v\"}" })
 
 take_json_string : List U8 -> { taken : List U8, rest : List U8 }
 take_json_string = |bytes|
@@ -1180,9 +1263,12 @@ string_help : StringState, U8 -> [Continue StringState, Break StringState]
 string_help = |state, byte|
     when (state, byte) is
         (Start, b) if b == '"' -> Continue(Chars(1))
+        (Start, b) if b == '{' -> Continue(Object(1))
         (Chars(n), b) if b == '"' -> Break(Finish((n + 1)))
         (Chars(n), b) if b == '\\' -> Continue(Escaped((n + 1)))
         (Chars(n), _) -> Continue(Chars((n + 1)))
+        (Object(n), b) if b == '}' -> Break(Finish((n + 1)))
+        (Object(n), _) -> Continue(Object((n + 1)))
         (Escaped(n), b) if is_escaped_char(b) -> Continue(Chars((n + 1)))
         (Escaped(n), b) if b == 'u' -> Continue(UnicodeA((n + 1)))
         (UnicodeA(n), b) if is_hex(b) -> Continue(UnicodeB((n + 1)))
@@ -1194,6 +1280,7 @@ string_help = |state, byte|
 StringState : [
     Start,
     Chars U64,
+    Object U64,
     Escaped U64,
     UnicodeA U64,
     UnicodeB U64,
@@ -1533,6 +1620,7 @@ array_opening_help = |state, byte|
     when (state, byte) is
         (BeforeOpeningBracket(n), b) if is_whitespace(b) -> Continue(BeforeOpeningBracket((n + 1)))
         (BeforeOpeningBracket(n), b) if b == '[' -> Continue(AfterOpeningBracket((n + 1)))
+        (BeforeOpeningBracket(n), b) if b == '{' -> Continue(AfterOpeningBracket((n + 1)))
         (AfterOpeningBracket(n), b) if is_whitespace(b) -> Continue(AfterOpeningBracket((n + 1)))
         _ -> Break(state)
 
@@ -1542,8 +1630,10 @@ array_closing_help = |state, byte|
         (BeforeNextElemOrClosingBracket(n), b) if is_whitespace(b) -> Continue(BeforeNextElemOrClosingBracket((n + 1)))
         (BeforeNextElemOrClosingBracket(n), b) if b == ',' -> Continue(BeforeNextElement((n + 1)))
         (BeforeNextElemOrClosingBracket(n), b) if b == ']' -> Continue(AfterClosingBracket((n + 1)))
+        (BeforeNextElemOrClosingBracket(n), b) if b == '}' -> Continue(AfterClosingBracket((n + 1)))
         (BeforeNextElement(n), b) if is_whitespace(b) -> Continue(BeforeNextElement((n + 1)))
         (BeforeNextElement(n), b) if b == ']' -> Continue(AfterClosingBracket((n + 1)))
+        (BeforeNextElement(n), b) if b == '}' -> Continue(AfterClosingBracket((n + 1)))
         (AfterClosingBracket(n), b) if is_whitespace(b) -> Continue(AfterClosingBracket((n + 1)))
         _ -> Break(state)
 


### PR DESCRIPTION
Two changes:
- Record decoded as `Str` - This enables handling json fields which may hold a dynamic type.
- Record decoded as a List of tuples - This is a work around to allow decoding `Dicts`.

Personally, I think the first change is a solid one -- it simply enables a fallback for json fields which could not otherwise be decoded at all, and should introduce no unexpected behavior.

I'm a little more iffy about the second change. While decoding Dicts could be useful, the implementation here is a little janky, and could introduce some unexpected behavior when decoding malformed JSON.

Let me know what you think!

> Note: current implementation would only allow decoding dynamic types which are stored as an object (ie: within `{...}`). It could be useful to decode any field as a Str, but this would require more significant changes.