### PR TITLE
Empty objects

### DIFF
--- a/package/Json.roc
+++ b/package/Json.roc
@@ -1948,6 +1948,17 @@ expect
     result = actual.result
     result == expected
 
+# Test decode of empty records
+expect
+    input = Str.to_utf8("{}")
+    actual : DecodeResult {}
+    actual = Decode.from_bytes_partial(input, utf8)
+
+    expected = Ok({})
+
+    result = actual.result
+    result == expected
+
 object_help : ObjectState, U8 -> [Break ObjectState, Continue ObjectState]
 object_help = |state, byte|
     when (state, byte) is


### PR DESCRIPTION
This adds support and a test for decoding empty objects into empty records. This is a corner case, but it comes up in an Elm-style "decode it all into an ADT and go from there" approach. 

Note: I accidentally tried to push my local branch to your repo instead of my own at first, so GitHub may have created an "empty-objects" branch on your repo. Sorry about that. 